### PR TITLE
Make unix-friendly line terminators the standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = false


### PR DESCRIPTION
Update line terminators to be LF instead of CRLF