### PR TITLE
Rename dual quicksort implementation to correct name as given in instructions

### DIFF
--- a/better_good_sorts.py
+++ b/better_good_sorts.py
@@ -32,7 +32,7 @@ def bottom_up_mergesort(lst: list) -> None:
         step *= 2
 
 
-def dual_pivot_quicksort(lst: list) -> None:
+def dual_quicksort(lst: list) -> None:
     # Add left and right bounds for partition to the stack, right bound is excluded
     stack = [(0, len(lst))]
     # Instead of making recursive partition calls, use a stack to hold the arguments and a while loop to
@@ -74,5 +74,5 @@ def dual_pivot_quicksort(lst: list) -> None:
 
 
 if __name__ == '__main__':
-    # print(confirm_sorter_correctness(dual_pivot_quicksort))
+    # print(confirm_sorter_correctness(dual_quicksort))
     pass

--- a/experiment6.py
+++ b/experiment6.py
@@ -1,11 +1,11 @@
-from better_good_sorts import dual_pivot_quicksort
+from better_good_sorts import dual_quicksort
 from good_sorts import quicksort
 from utilities import *
 
 
 def experiment6() -> None:
     name = 'Quick Sort'
-    sorters = [quicksort, dual_pivot_quicksort]
+    sorters = [quicksort, dual_quicksort]
     legend_labels = [name.lower().replace(' ', ''),
                      'dual_pivot_' + name.lower().replace(' ', '')]
     compare_plot_sorters(sorters, legend_labels, name, 100000, 20, 20, 2.25)


### PR DESCRIPTION
Change `dual_pivot_quicksort` to `dual_quicksort`.